### PR TITLE
Bug fix for exception during training when `tf` is not `None` and `opt.language_eval` is `0`

### DIFF
--- a/train.py
+++ b/train.py
@@ -150,8 +150,9 @@ def train(opt):
             # Write validation result into summary
             if tf is not None:
                 add_summary_value(tf_summary_writer, 'validation loss', val_loss, iteration)
-                for k,v in lang_stats.items():
-                    add_summary_value(tf_summary_writer, k, v, iteration)
+                if opt.language_eval == 1:
+                    for k,v in lang_stats.items():
+                        add_summary_value(tf_summary_writer, k, v, iteration)
                 tf_summary_writer.flush()
             val_result_history[iteration] = {'loss': val_loss, 'lang_stats': lang_stats, 'predictions': predictions}
 


### PR DESCRIPTION
With the current code, when `tf` is not `None` (TensorFlow is installed) and `opt.language_eval` is set to `0`, an exception will be thrown during training, as `lang_stats` returned by `eval_utils.eval_split()` is `None`, while the code is accessing its `items()` attribute.

This PR fixes the bug.