### PR TITLE
Fix diversity sampling in AttModel

### DIFF
--- a/captioning/models/AttModel.py
+++ b/captioning/models/AttModel.py
@@ -439,7 +439,7 @@ class AttModel(CaptionModel):
                     if t == 0:
                         unfinished = it != self.eos_idx
                     else:
-                        unfinished = seq[:,t-1] != self.pad_idx & seq[:,t-1] != self.eos_idx
+                        unfinished = (seq[:,t-1] != self.pad_idx) & (seq[:,t-1] != self.eos_idx)
                         it[~unfinished] = self.pad_idx
                         unfinished = unfinished & (it != self.eos_idx) # changed
                     seq[:,t] = it


### PR DESCRIPTION
Hello,

I wanted to use it for sampling diverse captions, and encountered an error in the `_diverse_sample` function ("int" and "bool" cannot be compared with operator &). 
It appeared linked to missing parenthesis, that this commit adds.

Thanks for maintaining this very useful repo!